### PR TITLE
Fix passing of test sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,7 @@ gradlePlugin {
 		}
 	}
 
-	testSourceSets(sourceSets.integrationTest)
-	testSourceSets(sourceSets.functionalTest)
+	testSourceSets(sourceSets.integrationTest, sourceSets.functionalTest)
 }
 
 configurations {


### PR DESCRIPTION
Calling testSourceSets() always clears any previously set source set. Therefore, all source sets have to be passed at once.