### PR TITLE
Provide Option to Set Download Base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/birdflyer-lszo/gradle-singlular-node/actions/workflows/build.yaml/badge.svg?branch=master)](https://github.com/birdflyer-lszo/gradle-singlular-node/actions/workflows/build.yaml)
 [![License](https://img.shields.io/github/license/node-gradle/gradle-node-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
-![Version](https://img.shields.io/badge/Version-1.1.0-orange.svg)
+![Version](https://img.shields.io/badge/Version-1.2.0-orange.svg)
 
 ## About
 
@@ -43,16 +43,17 @@ nodeJs {
 The following properties are available. Details on the default values and further behavior can be found in the Javadoc
 documentation.
 
-| Name              | Description                                                       |
-|-------------------|-------------------------------------------------------------------|
-| `nodeVersion`     | The version of NodeJS to install                                  |
-| `npmVersion`      | The version of NPM to install                                     |
-| `pnpmVersion`     | The version of PNPM to install                                    |
-| `yarnVersion`     | The version of Yarn to install                                    |
-| `installBaseDir`  | The base directory where NodeJS and Yarn are to be installed into |
-| `npmInstallArgs`  | Additional arguments to pass to NPM for installing packages       |
-| `pnpmInstallArgs` | Additional arguments to pass to PNPM for installing packages      |
-| `yarnInstallArgs` | Additional arguments to pass to Yarn for installing packages      |
+| Name              | Description                                                                        |
+|-------------------|------------------------------------------------------------------------------------|
+| `downloadBase`    | The base URL from which to download NodeJS (defaults to `https://nodejs.org/dist`) |
+| `nodeVersion`     | The version of NodeJS to install                                                   |
+| `npmVersion`      | The version of NPM to install                                                      |
+| `pnpmVersion`     | The version of PNPM to install                                                     |
+| `yarnVersion`     | The version of Yarn to install                                                     |
+| `installBaseDir`  | The base directory where NodeJS and Yarn are to be installed into                  |
+| `npmInstallArgs`  | Additional arguments to pass to NPM for installing packages                        |
+| `pnpmInstallArgs` | Additional arguments to pass to PNPM for installing packages                       |
+| `yarnInstallArgs` | Additional arguments to pass to Yarn for installing packages                       |
 
 ## Usage
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.2.0
+
+* Added a `nodeDownloadBase` option to provide custom base URL for NodeJS download
+* Eliminated the need to depend on `project.afterEvaluate`
+
+## 1.1.0
+
+* Cleaned up some documentation
+* Internal (non-breaking) refactorings and test improvements
+
 ## 1.0.0
 
-Initial open source release.
+Initial open source release. No longer available on plugins.gradle.org

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/SingularNodePluginSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/SingularNodePluginSpec.groovy
@@ -126,16 +126,35 @@ class SingularNodePluginSpec
 			def rootProject = rootProject()
 
 		when:
-			def repository = rootProject.repositories.findByName('nodejs')
+			def repository = rootProject.repositories.findByName('com.brunoritz.gradle.singularnode.nodeJsIvy')
 
 		then:
 			/*
              * The repository interface does not permit much more validation than what is below. In order to finally
              * validate the proper working of the repository a functional test of the plugin is needed.
              */
-			repository != null
 			IvyArtifactRepository.isInstance(repository)
 			repository.url.toString() == 'https://nodejs.org/dist'
+	}
+
+	def 'It shall be possible to specify an alternative download base URL'()
+	{
+		given:
+			def project = rootProject()
+			def configuration = project.extensions.getByType(NodeJsExtension)
+
+			configuration.nodeDownloadBase.set('https://user-defined-mirror.local')
+
+		when:
+			def repository = project.repositories.getByName('com.brunoritz.gradle.singularnode.nodeJsIvy')
+
+		then:
+			/*
+             * The repository interface does not permit much more validation than what is below. In order to finally
+             * validate the proper working of the repository a functional test of the plugin is needed.
+             */
+			IvyArtifactRepository.isInstance(repository)
+			repository.url.toString() == 'https://user-defined-mirror.local'
 	}
 
 	def 'It shall produce an error, if the plugin is applied to a subproject, but missing on the root project'()

--- a/src/main/java/com/brunoritz/gradle/singularnode/NodeJsExtension.java
+++ b/src/main/java/com/brunoritz/gradle/singularnode/NodeJsExtension.java
@@ -20,6 +20,14 @@ public class NodeJsExtension
 	public final Property<CharSequence> nodeVersion;
 
 	/**
+	 * The URL from which to download NodeJS. Subdirectories will be computed via an Ivy repository (and its dependency
+	 * pattern).
+	 * <p>
+	 * Defaults to {@code https://nodejs.org/dist}.
+	 */
+	public final Property<CharSequence> nodeDownloadBase;
+
+	/**
 	 * The version of NPM to be installed. If not defined, NPM will not be installed and trying to call the NPM
 	 * installation task will fail.
 	 */
@@ -63,6 +71,9 @@ public class NodeJsExtension
 	public NodeJsExtension(Project project)
 	{
 		Directory defaultInstallDir = project.getLayout().getProjectDirectory().dir("nodejs");
+
+		nodeDownloadBase = project.getObjects().property(CharSequence.class);
+		nodeDownloadBase.convention("https://nodejs.org/dist");
 
 		nodeVersion = project.getObjects().property(CharSequence.class);
 


### PR DESCRIPTION
The plugin is implemented to download the appropriate NodeJS distribution from https://nodejs.org/dist. When being used in corporate networks that URL is not always available and results in failures to install NodeJS.

Provide a `nodeDownloadBase` option via which users can override the default base URL to use whatever corporate mirror needed. The default download source will remain configured to https://nodejs.org/dist.