### PR TITLE
Make tool versions task inputs

### DIFF
--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/Configuration.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/Configuration.groovy
@@ -1,0 +1,17 @@
+package com.brunoritz.gradle.singularnode
+
+import org.gradle.api.Project
+
+final class Configuration
+{
+	private Configuration() {
+		throw new UnsupportedOperationException()
+	}
+
+	static void configureNodeJs(Project rootProject, @DelegatesTo(NodeJsExtension) Closure action)
+	{
+		def configuration = rootProject.extensions.findByType(NodeJsExtension)
+
+		action.rehydrate(configuration, this, this).call()
+	}
+}

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/MockNodeInstallation.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/MockNodeInstallation.groovy
@@ -17,7 +17,7 @@ final class MockNodeInstallation
 		project.copy {
 			from source
 			into dest
-			fileMode 0755
+			fileMode = 0755
 		}
 
 		return dest

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/SingularNodePluginSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/SingularNodePluginSpec.groovy
@@ -134,7 +134,7 @@ class SingularNodePluginSpec
              * validate the proper working of the repository a functional test of the plugin is needed.
              */
 			IvyArtifactRepository.isInstance(repository)
-			repository.url.toString() == 'https://nodejs.org/dist'
+			(repository as IvyArtifactRepository).url.toString() == 'https://nodejs.org/dist'
 	}
 
 	def 'It shall be possible to specify an alternative download base URL'()
@@ -154,7 +154,7 @@ class SingularNodePluginSpec
              * validate the proper working of the repository a functional test of the plugin is needed.
              */
 			IvyArtifactRepository.isInstance(repository)
-			repository.url.toString() == 'https://user-defined-mirror.local'
+			(repository as IvyArtifactRepository).url.toString() == 'https://user-defined-mirror.local'
 	}
 
 	def 'It shall produce an error, if the plugin is applied to a subproject, but missing on the root project'()

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/nodejs/InstallNodeJsTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/nodejs/InstallNodeJsTaskSpec.groovy
@@ -1,6 +1,7 @@
 package com.brunoritz.gradle.singularnode.nodejs
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import org.gradle.api.Project
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -19,7 +20,7 @@ class InstallNodeJsTaskSpec
 			def configuration = project.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
 			def simulatedLeftover = new File(layout.nodeJsInstallDir(), 'should-not-exist')
-			def task = project.tasks.getByPath('installNodeJs')
+			def task = installTaskFromProject(project)
 
 			task.nodeArchive.set(archriveResourceAsFile('nodejs-windows.zip'))
 			layout.nodeJsInstallDir().mkdirs()
@@ -39,7 +40,7 @@ class InstallNodeJsTaskSpec
 			def project = rootProject()
 			def configuration = project.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = project.tasks.getByPath('installNodeJs')
+			def task = installTaskFromProject(project)
 
 			task.nodeArchive.set(archriveResourceAsFile('nodejs-unix.tar.gz'))
 			layout.nodeJsInstallDir().mkdirs()
@@ -63,7 +64,7 @@ class InstallNodeJsTaskSpec
 			def project = rootProject()
 			def configuration = project.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = project.tasks.getByPath('installNodeJs')
+			def task = installTaskFromProject(project)
 
 			task.nodeArchive.set(archriveResourceAsFile('nodejs-windows.zip'))
 			layout.nodeJsInstallDir().mkdirs()
@@ -75,6 +76,11 @@ class InstallNodeJsTaskSpec
 			def sanitizedNpmCmd = configuration.installBaseDir.dir('node/npm.cmd').get().asFile
 
 			sanitizedNpmCmd.exists() && sanitizedNpmCmd.isFile()
+	}
+
+	private static InstallNodeJsTask installTaskFromProject(Project project)
+	{
+		return project.tasks.getByPath('installNodeJs') as InstallNodeJsTask
 	}
 
 	private File archriveResourceAsFile(String identifier)

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/npm/InstallNpmPackagesTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/npm/InstallNpmPackagesTaskSpec.groovy
@@ -1,6 +1,8 @@
 package com.brunoritz.gradle.singularnode.npm
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import com.brunoritz.gradle.singularnode.nodejs.InstallNodeJsTask
+import org.gradle.api.Project
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -24,7 +26,7 @@ class InstallNpmPackagesTaskSpec
 			def subProject = multiModuleProject()
 			def configuration = subProject.rootProject.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = subProject.tasks.getByPath('installNpmPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -46,7 +48,7 @@ class InstallNpmPackagesTaskSpec
 			def subProject = multiModuleProject()
 			def configuration = subProject.rootProject.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = subProject.tasks.getByPath('installNpmPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -71,7 +73,7 @@ class InstallNpmPackagesTaskSpec
 	{
 		given:
 			def subProject = multiModuleProject()
-			def task = subProject.tasks.getByPath('installNpmPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -82,5 +84,10 @@ class InstallNpmPackagesTaskSpec
 
 		then:
 			new File(subProject.file('node_modules'), '.install.executed').exists()
+	}
+
+	private static InstallNpmPackagesTask installTaskFromProject(Project project)
+	{
+		return project.tasks.getByPath('installNpmPackages') as InstallNpmPackagesTask
 	}
 }

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/npm/InstallNpmTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/npm/InstallNpmTaskSpec.groovy
@@ -1,6 +1,7 @@
 package com.brunoritz.gradle.singularnode.npm
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import org.gradle.api.Project
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -20,7 +21,7 @@ class InstallNpmTaskSpec
 			def installBase = simulateNodeInstallationInProject(project)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
 			def simulatedLeftover = new File(layout.npmInstallDirectory(), 'should-not-exist')
-			def task = project.tasks.getByPath('installNpm')
+			def task = installTaskFromProject(project)
 
 			configuration.npmVersion.set('1.2.3')
 			layout.npmInstallDirectory().mkdirs()
@@ -41,7 +42,7 @@ class InstallNpmTaskSpec
 			def project = rootProject()
 			def configuration = project.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = project.tasks.getByPath('installNpm')
+			def task = installTaskFromProject(project)
 
 			simulateNodeInstallationInProject(project)
 			configuration.npmVersion.set('1.2.3')
@@ -64,5 +65,10 @@ class InstallNpmTaskSpec
 				'--no-save ' +
 				"--prefix ${npmDir} " +
 				'npm@1.2.3'
+	}
+
+	private static InstallNpmTask installTaskFromProject(Project project)
+	{
+		return project.tasks.getByPath('installNpm') as InstallNpmTask
 	}
 }

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/npm/NpmTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/npm/NpmTaskSpec.groovy
@@ -1,9 +1,11 @@
 package com.brunoritz.gradle.singularnode.npm
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import com.brunoritz.gradle.singularnode.yarn.YarnTask
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
+import static com.brunoritz.gradle.singularnode.Configuration.configureNodeJs
 import static com.brunoritz.gradle.singularnode.MockNodeInstallation.simulateNodeInstallationInProject
 import static com.brunoritz.gradle.singularnode.ProjectFactory.multiModuleProject
 import static com.brunoritz.gradle.singularnode.platform.layout.InstallationLayoutFactory.platformDependentLayout
@@ -22,6 +24,24 @@ class NpmTaskSpec
 
 		then:
 			task.taskDependencies.getDependencies(task).contains(installTask)
+	}
+
+	def 'It shall make the NodeJS and NPM versions property inputs for reliable caching and to-to-date checks'()
+	{
+		given:
+			def subproject = multiModuleProject()
+
+			configureNodeJs(subproject.rootProject) {
+				nodeVersion.set('1.2.3')
+				npmVersion.set('5.6.7')
+			}
+
+		when:
+			def task = subproject.tasks.create('npmTask', NpmTask)
+
+		then:
+			task.inputs.properties['nodeJsVersion'] == '1.2.3'
+			task.inputs.properties['npmVersion'] == '5.6.7'
 	}
 
 	@IgnoreIf({ System.getProperty('os.name').containsIgnoreCase('windows') })

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/pnpm/InstallPnpmPackagesTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/pnpm/InstallPnpmPackagesTaskSpec.groovy
@@ -1,6 +1,7 @@
 package com.brunoritz.gradle.singularnode.pnpm
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import org.gradle.api.Project
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -24,7 +25,7 @@ class InstallPnpmPackagesTaskSpec
 			def subProject = multiModuleProject()
 			def configuration = subProject.rootProject.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = subProject.tasks.getByPath('installPnpmPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -46,7 +47,7 @@ class InstallPnpmPackagesTaskSpec
 			def subProject = multiModuleProject()
 			def configuration = subProject.rootProject.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = subProject.tasks.getByPath('installPnpmPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -71,7 +72,7 @@ class InstallPnpmPackagesTaskSpec
 	{
 		given:
 			def subProject = multiModuleProject()
-			def task = subProject.tasks.getByPath('installPnpmPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -82,5 +83,10 @@ class InstallPnpmPackagesTaskSpec
 
 		then:
 			new File(subProject.file('node_modules'), '.install.executed').exists()
+	}
+
+	private static InstallPnpmPackagesTask installTaskFromProject(Project project)
+	{
+		return project.tasks.getByPath('installPnpmPackages') as InstallPnpmPackagesTask
 	}
 }

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/pnpm/InstallPnpmTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/pnpm/InstallPnpmTaskSpec.groovy
@@ -1,6 +1,7 @@
 package com.brunoritz.gradle.singularnode.pnpm
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import org.gradle.api.Project
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -20,7 +21,7 @@ class InstallPnpmTaskSpec
 			def installBase = simulateNodeInstallationInProject(project)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
 			def simulatedLeftover = new File(layout.pnpmInstallDirectory(), 'should-not-exist')
-			def task = project.tasks.getByPath('installPnpm')
+			def task = installTaskFromProject(project)
 
 			configuration.pnpmVersion.set('1.2.3')
 			layout.pnpmInstallDirectory().mkdirs()
@@ -41,7 +42,7 @@ class InstallPnpmTaskSpec
 			def project = rootProject()
 			def configuration = project.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = project.tasks.getByPath('installPnpm')
+			def task = installTaskFromProject(project)
 
 			simulateNodeInstallationInProject(project)
 			configuration.pnpmVersion.set('1.2.3')
@@ -64,5 +65,10 @@ class InstallPnpmTaskSpec
 				'--no-save ' +
 				"--prefix ${pnpmDir} " +
 				'pnpm@1.2.3'
+	}
+
+	private static InstallPnpmTask installTaskFromProject(Project project)
+	{
+		return project.tasks.getByPath('installPnpm') as InstallPnpmTask
 	}
 }

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/pnpm/PnpmTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/pnpm/PnpmTaskSpec.groovy
@@ -4,6 +4,7 @@ import com.brunoritz.gradle.singularnode.NodeJsExtension
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
+import static com.brunoritz.gradle.singularnode.Configuration.configureNodeJs
 import static com.brunoritz.gradle.singularnode.MockNodeInstallation.simulateNodeInstallationInProject
 import static com.brunoritz.gradle.singularnode.ProjectFactory.multiModuleProject
 import static com.brunoritz.gradle.singularnode.platform.layout.InstallationLayoutFactory.platformDependentLayout
@@ -22,6 +23,24 @@ class PnpmTaskSpec
 
 		then:
 			task.taskDependencies.getDependencies(task).contains(installTask)
+	}
+
+	def 'It shall make the NodeJS and PNPM versions property inputs for reliable caching and to-to-date checks'()
+	{
+		given:
+			def subproject = multiModuleProject()
+
+			configureNodeJs(subproject.rootProject) {
+				nodeVersion.set('1.2.3')
+				pnpmVersion.set('5.6.7')
+			}
+
+		when:
+			def task = subproject.tasks.create('pnpmTask', PnpmTask)
+
+		then:
+			task.inputs.properties['nodeJsVersion'] == '1.2.3'
+			task.inputs.properties['pnpmVersion'] == '5.6.7'
 	}
 
 	@IgnoreIf({ System.getProperty('os.name').containsIgnoreCase('windows') })

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/yarn/InstallYarnPackagesTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/yarn/InstallYarnPackagesTaskSpec.groovy
@@ -1,6 +1,7 @@
 package com.brunoritz.gradle.singularnode.yarn
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import org.gradle.api.Project
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -24,7 +25,7 @@ class InstallYarnPackagesTaskSpec
 			def subProject = multiModuleProject()
 			def configuration = subProject.rootProject.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = subProject.tasks.getByPath('installYarnPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -46,7 +47,7 @@ class InstallYarnPackagesTaskSpec
 			def subProject = multiModuleProject()
 			def configuration = subProject.rootProject.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = subProject.tasks.getByPath('installYarnPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -71,7 +72,7 @@ class InstallYarnPackagesTaskSpec
 	{
 		given:
 			def subProject = multiModuleProject()
-			def task = subProject.tasks.getByPath('installYarnPackages')
+			def task = installTaskFromProject(subProject)
 
 			subProject.projectDir.mkdirs()
 			subProject.file('node_modules').mkdirs()
@@ -82,5 +83,10 @@ class InstallYarnPackagesTaskSpec
 
 		then:
 			new File(subProject.projectDir, '.install.executed').exists()
+	}
+
+	private static InstallYarnPackagesTask installTaskFromProject(Project project)
+	{
+		return project.tasks.getByPath('installYarnPackages') as InstallYarnPackagesTask
 	}
 }

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/yarn/InstallYarnTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/yarn/InstallYarnTaskSpec.groovy
@@ -1,6 +1,7 @@
 package com.brunoritz.gradle.singularnode.yarn
 
 import com.brunoritz.gradle.singularnode.NodeJsExtension
+import org.gradle.api.Project
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -20,7 +21,7 @@ class InstallYarnTaskSpec
 			def installBase = simulateNodeInstallationInProject(project)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
 			def simulatedLeftover = new File(layout.yarnInstallDirectory(), 'should-not-exist')
-			def task = project.tasks.getByPath('installYarn')
+			def task = installTaskFromProject(project)
 
 			configuration.yarnVersion.set('1.2.3')
 			layout.yarnInstallDirectory().mkdirs()
@@ -41,7 +42,7 @@ class InstallYarnTaskSpec
 			def project = rootProject()
 			def configuration = project.extensions.getByType(NodeJsExtension)
 			def layout = platformDependentLayout(configuration.installBaseDir).get()
-			def task = project.tasks.getByPath('installYarn')
+			def task = installTaskFromProject(project)
 
 			simulateNodeInstallationInProject(project)
 			configuration.yarnVersion.set('1.2.3')
@@ -64,5 +65,10 @@ class InstallYarnTaskSpec
 				'--no-save ' +
 				"--prefix ${yarnDir} " +
 				'yarn@1.2.3'
+	}
+
+	private static InstallYarnTask installTaskFromProject(Project project)
+	{
+		return project.tasks.getByPath('installYarn') as InstallYarnTask
 	}
 }

--- a/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/yarn/YarnTaskSpec.groovy
+++ b/src/integrationTest/groovy/com/brunoritz/gradle/singularnode/yarn/YarnTaskSpec.groovy
@@ -4,6 +4,7 @@ import com.brunoritz.gradle.singularnode.NodeJsExtension
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
+import static com.brunoritz.gradle.singularnode.Configuration.configureNodeJs
 import static com.brunoritz.gradle.singularnode.MockNodeInstallation.simulateNodeInstallationInProject
 import static com.brunoritz.gradle.singularnode.ProjectFactory.multiModuleProject
 import static com.brunoritz.gradle.singularnode.platform.layout.InstallationLayoutFactory.platformDependentLayout
@@ -22,6 +23,24 @@ class YarnTaskSpec
 
 		then:
 			task.taskDependencies.getDependencies(task).contains(installTask)
+	}
+
+	def 'It shall make the NodeJS and Yarn versions property inputs for reliable caching and to-to-date checks'()
+	{
+		given:
+			def subproject = multiModuleProject()
+
+			configureNodeJs(subproject.rootProject) {
+				nodeVersion.set('1.2.3')
+				yarnVersion.set('berry')
+			}
+
+		when:
+			def task = subproject.tasks.create('yarnTask', YarnTask)
+
+		then:
+			task.inputs.properties['nodeJsVersion'] == '1.2.3'
+			task.inputs.properties['yarnVersion'] == 'berry'
 	}
 
 	@IgnoreIf({ System.getProperty('os.name').containsIgnoreCase('windows') })

--- a/src/main/java/com/brunoritz/gradle/singularnode/npm/NpmSetup.java
+++ b/src/main/java/com/brunoritz/gradle/singularnode/npm/NpmSetup.java
@@ -83,6 +83,9 @@ public final class NpmSetup
 				newNpmTask.dependsOn(installNpmPackagesTask);
 				newNpmTask.getWorkingDirectory().set(project.getProjectDir());
 				newNpmTask.getInstallationLayout().set(layout);
+
+				newNpmTask.getInputs().property("nodeJsVersion", configuration.nodeVersion);
+				newNpmTask.getInputs().property("npmVersion", configuration.npmVersion);
 			}
 		});
 

--- a/src/main/java/com/brunoritz/gradle/singularnode/pnpm/PnpmSetup.java
+++ b/src/main/java/com/brunoritz/gradle/singularnode/pnpm/PnpmSetup.java
@@ -83,6 +83,9 @@ public final class PnpmSetup
 				newPnpmTask.dependsOn(installPnpmPackagesTask);
 				newPnpmTask.getWorkingDirectory().set(project.getProjectDir());
 				newPnpmTask.getInstallationLayout().set(layout);
+
+				newPnpmTask.getInputs().property("nodeJsVersion", configuration.nodeVersion);
+				newPnpmTask.getInputs().property("pnpmVersion", configuration.pnpmVersion);
 			}
 		});
 

--- a/src/main/java/com/brunoritz/gradle/singularnode/yarn/YarnSetup.java
+++ b/src/main/java/com/brunoritz/gradle/singularnode/yarn/YarnSetup.java
@@ -83,6 +83,9 @@ public final class YarnSetup
 				newYarnTask.dependsOn(installYarnPackagesTask);
 				newYarnTask.getWorkingDirectory().set(project.getProjectDir());
 				newYarnTask.getInstallationLayout().set(layout);
+
+				newYarnTask.getInputs().property("nodeJsVersion", configuration.nodeVersion);
+				newYarnTask.getInputs().property("yarnVersion", configuration.yarnVersion);
 			}
 		});
 

--- a/src/test/groovy/com/brunoritz/gradle/singularnode/platform/NodeCommandSpec.groovy
+++ b/src/test/groovy/com/brunoritz/gradle/singularnode/platform/NodeCommandSpec.groovy
@@ -28,7 +28,7 @@ class NodeCommandSpec
 			command.execute()
 
 		then:
-			1 * processes.exec { _ as Action } >> { arguments -> arguments[0].execute(execSpec) }
+			1 * processes.exec { _ as Action } >> { Action action -> action.execute(execSpec) }
 			1 * layout.pathOfNodeExecutable() >> NODE_EXECUTABLE
 			1 * layout.nodeJsBinDirectory() >> NODE_BIN_DIR
 			1 * execSpec.setExecutable(nodeExecutable.absolutePath)
@@ -50,11 +50,11 @@ class NodeCommandSpec
 				.execute()
 
 		then:
-			1 * processes.exec { _ as Action } >> { arguments -> arguments[0].execute(execSpec) }
+			1 * processes.exec { _ as Action } >> { Action action -> action.execute(execSpec) }
 			1 * layout.pathOfNodeExecutable() >> NODE_EXECUTABLE
 			1 * layout.nodeJsBinDirectory() >> NODE_BIN_DIR
-			1 * execSpec.environment(_) >> { arguments ->
-				assert arguments[0]['OVERRIDE'] == 'new-value'
+			1 * execSpec.environment(_) >> { Map<String, String> envVars ->
+				assert envVars['OVERRIDE'] == 'new-value'
 
 				return execSpec
 			}
@@ -80,7 +80,7 @@ class NodeCommandSpec
 				.execute()
 
 		then:
-			1 * processes.exec { _ as Action } >> { arguments -> arguments[0].execute(execSpec) }
+			1 * processes.exec { _ as Action } >> { Action action -> action.execute(execSpec) }
 
 		then:
 			1 * layout.pathOfNodeExecutable() >> NODE_EXECUTABLE
@@ -112,15 +112,15 @@ class NodeCommandSpec
 				.execute()
 
 		then:
-			1 * processes.exec { _ as Action } >> { arguments -> arguments[0].execute(execSpec) }
+			1 * processes.exec { _ as Action } >> { Action action -> action.execute(execSpec) }
 
 		then:
 			1 * layout.pathOfNodeExecutable() >> NODE_EXECUTABLE
 			1 * layout.nodeJsBinDirectory() >> NODE_BIN_DIR
-			1 * execSpec.environment(_) >> { arguments ->
-				assert arguments[0]['FOO'] == 'BAR'
-				assert arguments[0]['BAR'] == 'BAZ'
-				assert arguments[0]['SOMETHING'] == 'NOTHING'
+			1 * execSpec.environment(_) >> { Map<String, String> envVars ->
+				assert envVars['FOO'] == 'BAR'
+				assert envVars['BAR'] == 'BAZ'
+				assert envVars['SOMETHING'] == 'NOTHING'
 
 				return execSpec
 			}
@@ -139,13 +139,13 @@ class NodeCommandSpec
 			command.execute()
 
 		then:
-			1 * processes.exec { _ as Action } >> { arguments -> arguments[0].execute(execSpec) }
+			1 * processes.exec { _ as Action } >> { Action action -> action.execute(execSpec) }
 
 		then:
 			1 * layout.pathOfNodeExecutable() >> NODE_EXECUTABLE
 			1 * layout.nodeJsBinDirectory() >> NODE_BIN_DIR
-			1 * execSpec.environment(_) >> { arguments ->
-				assert arguments[0]['PATH'].startsWith("${NODE_BIN_DIR.absolutePath}${File.pathSeparator}")
+			1 * execSpec.environment(_) >> { Map<String, String> envVars ->
+				assert envVars['PATH'].startsWith("${NODE_BIN_DIR.absolutePath}${File.pathSeparator}")
 
 				return execSpec
 			}


### PR DESCRIPTION
In order to ensure custom tasks run again when the tooling versions change, make the version numbers inputs of `NpmTask`, `PnpmTask` and `YarnTask`.

With the versions being inputs, a task will be outdated when the tool versions change.